### PR TITLE
Test "root" is allowed as section pattern

### DIFF
--- a/filetree/CMakeLists.txt
+++ b/filetree/CMakeLists.txt
@@ -46,6 +46,9 @@ new_ec_test(root_file root_file.in root_file/test.a "^[ \t\n\r]*$")
 # Test that search stops at root EditorConfig file
 new_ec_test(root_file_mixed_case root_file.in root_mixed/test.a "^child=true[ \t\n\r]*$")
 
+# Test that search stops at root EditorConfig file
+new_ec_test(root_pattern root_file.in root "^name=root[ \t\n\r]*$")
+
 # Tests path separator match
 new_ec_test(path_separator path_separator.in path/separator "^key=value[ \t\n\r]*$")
 

--- a/filetree/root_file.in
+++ b/filetree/root_file.in
@@ -2,3 +2,6 @@ root = true
 
 [test.a]
 key=value
+
+[root]
+name=root


### PR DESCRIPTION
Depending on INI parsing implementation details, it seems possible to mistakenly treat `"root"` as special key that may clobber a legitimate root filename.

``` ini
# top-most EditorConfig file
root = true

# Unix-style newlines with a newline ending every file
[*]
end_of_line = lf
insert_final_newline = true

# Matches multiple files with brace expansion notation
# Set default charset
[*.{js,py}]
charset = utf-8
```

Might be parsed into a Dictionary/Hash/Object that looks like:

``` json
{
  "root": true,
  "*": { "end_of_line": "lf", "insert_final_newline": "true" },
  "*.{js,py}": { "charset": "utf-8" }
}
```

This would add a high level test to ensure a section named "root" would be handled correctly.