### PR TITLE
Test unknown properties outside of section are ignored

### DIFF
--- a/filetree/root_mixed/root_file.in
+++ b/filetree/root_mixed/root_file.in
@@ -1,4 +1,5 @@
 root = TrUe
+ignore = false
 
 [*.a]
 child=true


### PR DESCRIPTION
`root` is the only special property outside of any section. But I think we should still test somewhere to make sure any other property exists there is simply ignored.