### PR TITLE
Fix #15 Do not pass file names ending with space on Windows as they are

### DIFF
--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -55,9 +55,16 @@ new_ec_test(spaces_after_property_value whitespace.in test5.c
 new_ec_test(blank_lines_between_properties whitespace.in test6.c 
     "^key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*$")
 
-# test spaces in section name
-new_ec_test(spaces_in_section_name whitespace.in " test 7 "
-    "^key=value[ \t\n\r]*$")
+# test spaces at the beginning of a section name
+new_ec_test(spaces_at_section_name_start whitespace.in " test 71"
+    "^key71=value71[ \t\n\r]*$")
+
+# test spaces at the end of a section name
+# skipped on Windows because filenames with trailing spaces are illegal there
+if(NOT WIN32)
+    new_ec_test(spaces_at_section_name_end whitespace.in "test 72 "
+        "^key72=value72[ \t\n\r]*$")
+endif()
 
 # test spaces before section name are ignored
 new_ec_test(spaces_before_section_name whitespace.in test8.c

--- a/parser/whitespace.in
+++ b/parser/whitespace.in
@@ -29,9 +29,13 @@ key1=value1
 
 key2=value2
 
-; spaces in section name
-[ test 7 ]
-key=value
+; spaces at the beginning of a section name
+[ test 71]
+key71=value71
+
+; spaces at the end of a section name
+[test 72 ]
+key72=value72
 
 ; spaces before section name
   [test8.c]


### PR DESCRIPTION
illegal there

This basically splits the existing `spaces_in_section_name` test into two new tests `spaces_at_section_name_start` and `spaces_at_section_name_end` the latter made skipped on Windows because filenames with trailing spaces are illegal there.

The following build shows that current fix works as expected for `editorconfig-core-c` on Windows  - i.e. that  `spaces_at_section_name_start` is passing and that `spaces_at_section_name_end` is not executed: https://ci.appveyor.com/project/ppalaga/editorconfig-core-c/build/1.0.94#L1050

And this build shows that the current fix works as expected for `editorconfig-core-c` on Linux - i.e. that both `spaces_at_section_name_start` and `spaces_at_section_name_end` pass there: https://travis-ci.org/ppalaga/editorconfig-core-c/builds/308148679