### PR TITLE
Update tests to permit any order of output lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
-# Copyright (c) 2011-2012 EditorConfig Team
+# Copyright (c) 2011-2018 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -24,16 +24,18 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-
 # Don't check any language compiler. This project is for EditorConfig Core
 # testing only.
 project(editorconfig-core-test NONE)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(multiline_matcher)
 
 # Only when we are using editorconfig-core-test independently should we check
 # cmake version, set EDITORCONFIG_CMD as cache string, and enable_testing()
 # here.
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-    cmake_minimum_required(VERSION 2.6)
+    cmake_minimum_required(VERSION 3.1.0)
     set(EDITORCONFIG_CMD "editorconfig" CACHE STRING "editorconfig command.")
     enable_testing()
 endif()
@@ -44,6 +46,42 @@ function(new_ec_test name ec_file src_file regex)
         "${CMAKE_CURRENT_SOURCE_DIR}/${src_file}")
     set_tests_properties(${name} PROPERTIES PASS_REGULAR_EXPRESSION "${regex}")
 endfunction()
+
+# Test that the output _doesn't_ match a given regex
+function(new_ec_test_does_not_match name ec_file src_file regex)
+    add_test(${name} ${EDITORCONFIG_CMD} -f ${ec_file}
+        "${CMAKE_CURRENT_SOURCE_DIR}/${src_file}")
+    set_tests_properties(${name} PROPERTIES FAIL_REGULAR_EXPRESSION "${regex}")
+endfunction()
+
+
+# Test for multiple regexes in any order in the output.  Each regex should
+# match one line.
+# Example:
+#   ec_test_lines(NAME foo EC_FILE ec.in SRC_FILE src_file EXPECTED "a" "b" "c")
+function(ec_test_lines)
+
+    # Parse the arguments
+    set(one_value_keywords NAME EC_FILE SRC_FILE)
+    set(multi_value_keywords EXPECTED)
+    cmake_parse_arguments(P "" "${one_value_keywords}" "${multi_value_keywords}" ${ARGN})
+
+    #message("Adding test:")
+    #message("Name:              ${P_NAME}")
+    #message("Editorconfig file: ${P_EC_FILE}")
+    #message("Source file:       ${P_SRC_FILE}")
+    #message("Regexes:           ${P_EXPECTED}")
+
+    # Build the joint regex by building all possible permutations of
+    # the input regex.
+    make_regex_of_permutations(RETVAL regex EXPECTED ${P_EXPECTED})
+    #message("Bulk regex:        ${regex}")
+
+    add_test("${P_NAME}" ${EDITORCONFIG_CMD} -f "${P_EC_FILE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/${P_SRC_FILE}")
+    set_tests_properties("${P_NAME}"
+        PROPERTIES PASS_REGULAR_EXPRESSION "${regex}")
+endfunction(ec_test_lines)
 
 # The tests that requires version specified
 function(new_ec_test_version name ec_file src_file regex version)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2011-2012 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -44,6 +44,14 @@ set_tests_properties(test_short_version_switch PROPERTIES
 add_test(multiple_files_on_command_line ${EDITORCONFIG_CMD} -f cli.in
     "${CMAKE_CURRENT_SOURCE_DIR}/file1.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/file2.cpp")
+
+make_regex_of_permutations(     # each pair of lines must be in that order,
+    RETVAL multi_files_regex    # but the pairs can be in either order.
+    EXPECTED
+    "\\[${CMAKE_CURRENT_SOURCE_DIR}/file1.c\\][ \t]*[\n\r]+key1=value1[ \t]*"
+    "\\[${CMAKE_CURRENT_SOURCE_DIR}/file2.cpp\\][ \t]*[\n\r]+key2=value2[ \t]*"
+)
+
 set_tests_properties(multiple_files_on_command_line PROPERTIES
-    PASS_REGULAR_EXPRESSION
-    "^\\[${CMAKE_CURRENT_SOURCE_DIR}/file1.c\\][ \t]*[\n\r]+key1=value1[ \t]*[\n\r]+\\[${CMAKE_CURRENT_SOURCE_DIR}/file2.cpp\\][ \t]*[\n\r]+key2=value2[ \t\n\r]*$")
+    PASS_REGULAR_EXPRESSION "${multi_files_regex}"
+)

--- a/cmake/multiline_matcher.cmake
+++ b/cmake/multiline_matcher.cmake
@@ -1,0 +1,340 @@
+# multiline_matcher.cmake: Make a regex that will match multiple consecutive
+# lines in any order.  For use in editorconfig; see
+# https://github.com/editorconfig/editorconfig/issues/375 .
+
+set( CMAKE_LEGACY_CYGWIN_WIN32 0 )
+cmake_minimum_required( VERSION 3.1.0 )
+cmake_policy(SET CMP0054 NEW)
+
+# Conventions:
+#   - "P_*" are parameters parsed using cmake_parse_arguments
+#   - Any parameter called "RETVAL", "RETVAL_*", or "*_NAME" should be given
+#       the name of a variable in the caller's scope into which to
+#       store results.
+
+# This file implements the Johnson-Trotter
+# algorithm described at https://sourceforge.net/projects/swappermutation/
+# (by wvasperen, BSD licensed).  Additional info is at
+# http://www.cut-the-knot.org/Curriculum/Combinatorics/JohnsonTrotter.shtml
+# and https://tropenhitze.wordpress.com/2010/01/25/steinhaus-johnson-trotter-permutation-algorithm-explained-and-implemented-in-java/ .
+
+###########################################################################
+# Constants
+
+set( ECT_MATCH_LINE_START "(^|[\n\r]+)" )
+set( ECT_MATCH_LINE_END "[\n\r]+" )
+#set( ECT_MATCH_LINE_START "<" )    # Easier to read when debugging
+#set( ECT_MATCH_LINE_END ">" )
+set( ECT_LEFT "- 1" )       # CAUTION: these are strings so I can use them
+set( ECT_RIGHT "+ 1" )      # directly in math.
+set( ECT_DONE -42 )   # special flag index that means we're done
+
+###########################################################################
+# Utility functions
+
+# Set an element of a list
+function( list_set LIST_NAME IDX VAL )
+    list( LENGTH "${LIST_NAME}" len )
+    math( EXPR max_idx "${len} - 1" )
+
+    set( temp ${${LIST_NAME}} )
+
+    list( REMOVE_AT temp "${IDX}" )
+    if( "${IDX}" EQUAL "${max_idx}" )
+        list( APPEND temp "${VAL}" )
+    else()
+        list( INSERT temp "${IDX}" "${VAL}" )
+    endif()
+
+    set( ${LIST_NAME} "${temp}" PARENT_SCOPE )  # send array back to caller
+endfunction( list_set )
+
+# Swap two elements in a list in-place
+function( list_swap LIST_NAME IDX1 IDX2 )
+    set( temp ${${LIST_NAME}} )   # Copy the list into our scope
+
+    # Do the swap
+    list( GET "${LIST_NAME}" "${IDX1}" item1 )
+    list( GET "${LIST_NAME}" "${IDX2}" item2 )
+
+    list_set( temp "${IDX1}" "${item2}" )
+    list_set( temp "${IDX2}" "${item1}" )
+
+    set( ${LIST_NAME} "${temp}" PARENT_SCOPE )  # send array back to caller
+endfunction( list_swap )
+
+###########################################################################
+# Johnson-Trotter functions
+
+function( switch_direction DIRS_NAME IDX )
+    #message( "Switching direction in ${${DIRS_NAME}} at ${IDX}" )
+    set( dirs ${${DIRS_NAME}} )   # Copy the list into our scope
+
+    list( GET dirs "${curridx}" this_dir )
+    if( "${this_dir}" STREQUAL "${ECT_LEFT}" )
+        set( new_dir "${ECT_RIGHT}" )
+    else()
+        set( new_dir "${ECT_LEFT}" )
+    endif()
+    list_set( dirs "${curridx}" "${new_dir}" )
+
+    set( ${DIRS_NAME} "${dirs}" PARENT_SCOPE )  # send array back to caller
+endfunction( switch_direction )
+
+# Is item IDX a mobile item in A[]?
+function( jt_is_mobile )
+    # Argument parsing
+    set( one_value_keywords RETVAL IDX )
+    set( multi_value_keywords A DIRS )
+    cmake_parse_arguments( P "" "${one_value_keywords}" "${multi_value_keywords}" ${ARGN} )
+
+    list( LENGTH P_A len_a )
+    math( EXPR max_a "${len_a} - 1" )
+    list( GET P_DIRS "${P_IDX}" curr_dir )
+
+    #message( "jt_is_mobile: retval name ${P_RETVAL} index ${P_IDX} dir ${curr_dir}" )
+    #message( "              A ${P_A} len ${len_a}; dirs ${P_DIRS}" )
+
+    set( rv TRUE )
+        # unless one of the tests below says otherwise
+
+    if(  ( "${P_IDX}" EQUAL "0" ) AND ( "${curr_dir}" STREQUAL "${ECT_LEFT}" )  )
+        set( rv FALSE )
+
+    elseif(  ( "${P_IDX}" EQUAL "${max_a}" ) AND ( "${curr_dir}" STREQUAL "${ECT_RIGHT}" )  )
+        set( rv FALSE )
+
+    else()
+        list( GET a "${P_IDX}" curr_a )
+        math( EXPR next_idx "${P_IDX} ${curr_dir}" )   # curr_dir = +/-1
+        list( GET a "${next_idx}" next_a )
+
+        if( "${next_a}" GREATER "${curr_a}" )
+            set( rv FALSE )
+        endif()
+
+    endif()
+
+    #message( "              Result: ${rv}" )
+    set( ${P_RETVAL} "${rv}" PARENT_SCOPE )
+endfunction( jt_is_mobile )
+
+# Find the position of the largest mobile integer in A[]
+function( jt_find_mobile )
+    # Argument parsing
+    set( one_value_keywords RETVAL_IDX RETVAL_ITEM )
+    set( multi_value_keywords A DIRS )
+    cmake_parse_arguments( P "" "${one_value_keywords}" "${multi_value_keywords}" ${ARGN} )
+
+    # Work
+    set( chosen -1 )      # item numbers are >=1
+    set( chosen_idx -1 )
+    set( saw_mobile FALSE )   # if it's false at the end, we're done
+
+    list( LENGTH P_A len_a )
+    math( EXPR max_a "${len_a} - 1" )
+
+    foreach( curridx RANGE 0 "${max_a}" )
+        list( GET P_A "${curridx}" curr_item )
+        jt_is_mobile( RETVAL ismobile IDX "${curridx}" A ${P_A} DIRS ${P_DIRS} )
+
+        if( "${ismobile}" )
+            set( saw_mobile TRUE )
+        endif()
+
+        if( "${ismobile}" AND ( "${curr_item}" GREATER "${chosen}" ) )
+            set( chosen "${curr_item}" )
+            set( chosen_idx "${curridx}" )
+        endif()
+    endforeach()
+
+    if( "${saw_mobile}" )
+        set( ${P_RETVAL_IDX} "${chosen_idx}" PARENT_SCOPE )
+        set( ${P_RETVAL_ITEM} "${chosen}" PARENT_SCOPE )
+    else()
+        set( ${P_RETVAL_IDX} "${ECT_DONE}" PARENT_SCOPE )
+    endif()
+endfunction( jt_find_mobile )
+
+# Make the next permutation.
+function( jt_make_next )
+    # Argument parsing
+    set( one_value_keywords DONE A_NAME DIRS_NAME )
+    set( multi_value_keywords "" )
+    cmake_parse_arguments( P "" "${one_value_keywords}" "${multi_value_keywords}" ${ARGN} )
+
+    set( new_a ${${P_A_NAME}} )       # local work vars
+    set( new_dirs ${${P_DIRS_NAME}} )
+
+    #message( "jt_make_next: A_NAME ${P_A_NAME}; DIRS_NAME ${P_DIRS_NAME}" )
+    #message( "jt_make_next: A ${new_a}; dirs ${new_dirs}" )
+
+    jt_find_mobile( RETVAL_IDX mobile_idx RETVAL_ITEM mobile_item A ${new_a} DIRS ${new_dirs} )
+
+    if( "${mobile_idx}" EQUAL "${ECT_DONE}" )
+        set( ${P_DONE} TRUE PARENT_SCOPE )
+    else()
+        #message( "  found mobile item ${mobile_item} at ${mobile_idx}" )
+
+        set( ${P_DONE} FALSE PARENT_SCOPE )
+
+        # Swap the largest mobile index with its neighbor
+        list( GET new_dirs "${mobile_idx}" mobile_dir )
+        math( EXPR next_idx "${mobile_idx} ${mobile_dir}" )
+        list( GET new_a "${next_idx}" next_item )
+        list( GET new_dirs "${next_idx}" next_dir )
+
+        # Do the swap
+        list_swap( new_a "${mobile_idx}" "${next_idx}" )
+        list_swap( new_dirs "${mobile_idx}" "${next_idx}" )
+
+        # Now reverse the direction of all items larger than the latest
+        # mobile item.
+        list( LENGTH new_a len_a )
+        math( EXPR max_a "${len_a} - 1" )
+        foreach( curridx RANGE 0 "${max_a}" )
+            list( GET new_a "${curridx}" this_a )
+            if( ${this_a} GREATER "${mobile_item}" )
+                switch_direction( new_dirs "${curridx}" )
+            endif()
+
+        endforeach()
+
+        #message( "  after mod: A ${new_a}; dirs ${new_dirs}" )
+
+        # send locals back to caller
+        set( ${P_A_NAME} "${new_a}" PARENT_SCOPE )
+        set( ${P_DIRS_NAME} "${new_dirs}" PARENT_SCOPE )
+    endif()
+
+endfunction( jt_make_next )
+
+# Assemble one permutation into a regex that will match the given regexes on
+# consecutive lines, in the given order.
+function( re_assemble_perm )
+
+    # Argument parsing
+    set( one_value_keywords RETVAL )
+    set( multi_value_keywords ORDER EXPECTED )
+    cmake_parse_arguments( P "" "${one_value_keywords}" "${multi_value_keywords}" ${ARGN} )
+
+    #message( "Assembling in order ${P_ORDER} the regexes ${P_EXPECTED}" )
+
+    list( LENGTH P_EXPECTED NR )
+    math( EXPR maxr "${NR} - 1" )
+    set( rv "${ECT_MATCH_LINE_START}" )
+    foreach( idx RANGE 0 "${maxr}" )
+        list( GET P_ORDER "${idx}" curr_order )
+        math( EXPR curr_order "${curr_order} - 1" )   # 1-based -> 0-based
+        list( GET P_EXPECTED "${curr_order}" curr_regex )
+        set( rv "${rv}${curr_regex}${ECT_MATCH_LINE_END}" )
+    endforeach()
+
+    set( ${P_RETVAL} "${rv}" PARENT_SCOPE )     # return
+endfunction( re_assemble_perm )
+
+# Make a regex to match the given regexes on successive lines, in any order.
+# Each input regex should match one whole line.  A line anchor at the beginning
+# and at the end will automatically be added, but leading/trailing whitespace
+# is left to the caller.
+function( make_regex_of_permutations )
+
+    # Argument parsing
+    set( options FORCE )
+    set( one_value_keywords RETVAL )
+    set( multi_value_keywords EXPECTED )
+    cmake_parse_arguments( P "${options}" "${one_value_keywords}" "${multi_value_keywords}" ${ARGN} )
+
+    #message( "Retval name:       " "${P_RETVAL}" )
+    #message( "Regexes:           " "${P_EXPECTED}" )
+    #message( "Force:             " "${P_FORCE}" )
+
+    list( LENGTH P_EXPECTED NR )     # NR = how many regexes
+
+    if("${NR}" EQUAL "0")
+        message(FATAL_ERROR "EXPECTED argument required")
+        return()
+    endif()
+
+    # Degenerate case: single element.  Warn because there is almost certainly
+    # no need to use this macro in that case.
+    if("${NR}" EQUAL "1")
+        list(GET P_EXPECTED 0 elem)
+        message(WARNING "Only one regex given.  Did you forget one?")
+        set( ${P_RETVAL} "${elem}" PARENT_SCOPE )
+        return()
+    endif()
+
+    # CMake regexes are limited to nine groups, as far as I can tell.  That
+    # means we can only use regexes with go up to 3! = 6 permutations.
+    # However, this function can generate any number of permutations,
+    # if you specify FORCE.
+    if( ( NOT "${P_FORCE}" ) AND ( "${NR}" GREATER "3" ) )
+        message(FATAL_ERROR "CMake can't handle as many parentheses as I'll need to handle ${NR} regexes.  Sorry!")
+    endif()
+
+    # Get number of permutations, and set up for the Johnson-Trotter
+    # algorithm
+    set( NP 1 )                     # NP = how many permutations = NR!
+    set( a "1" )                    # J-T current permutation
+    set( dirs "${ECT_LEFT}" )       # J-T direction
+    foreach( idx RANGE 2 "${NR}" )  # NR >= 2 because we checked 0 and 1 above
+        math( EXPR NP "${NP} * ${idx}" )
+        set( a "${a};${idx}" )
+        set( dirs "${dirs};${ECT_LEFT}" )
+    endforeach()
+
+    #message( "  Regexes:      ${NR}" )
+    #message( "  Permutations: ${NP}" )
+    #message( "  a:            ${a}" )
+    #message( "  dirs:         ${dirs}" )
+
+    # Do perm 1
+    re_assemble_perm( RETVAL curr_re ORDER ${a} EXPECTED ${P_EXPECTED} )
+    #message( "  Perm 0 is: ${curr_re}" )
+    set( rv "${curr_re}" )      # the regex we are building
+
+    # Main loop
+    foreach( permidx RANGE 2 "${NP}" )  # 2..${NP} inclusive
+
+        jt_make_next( DONE jt_done A_NAME a DIRS_NAME dirs )
+        if( jt_done )
+            #message( WARNING "Done early!  Possible logic error?" )
+            break()
+        endif( jt_done )
+        #message( "Got new order ${a}" )
+
+        re_assemble_perm( RETVAL curr_re ORDER ${a} EXPECTED ${P_EXPECTED} )
+        #message( "  Perm is: ${curr_re}" )
+        set( rv "${rv}|${curr_re}" )
+    endforeach()
+
+    #message( "  Complete RE is: /${rv}/" )
+
+    set( ${P_RETVAL} "${rv}" PARENT_SCOPE )     # return
+endfunction( make_regex_of_permutations )
+
+# BSD-2-Clause
+# Copyright 2018 Christopher White (cxw42 at GitHub; http://devwrench.com)
+# All rights reserved
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.

--- a/filetree/CMakeLists.txt
+++ b/filetree/CMakeLists.txt
@@ -54,6 +54,7 @@ new_ec_test(path_separator path_separator.in path/separator "^key=value[ \t\n\r]
 
 # Windows style path separator in the command line should work on Windows, but
 # should not work on other systems
+# TODO figure out how to handle Cygwin
 if(WIN32)
     set(path_separator_backslash_in_cmd_line_regex "^key=value[ \t\n\r]*$")
 else(WIN32)
@@ -79,7 +80,7 @@ new_ec_test(windows_separator path_separator.in windows/separator "^[ \t\n\r]*$"
 new_ec_test(windows_separator2 path_separator.in windows/separator2 "^[ \t\n\r]*$")
 
 # Globs with backslash in it but should be considered as file name on Non-Windows system
-if(NOT WIN32)
+if( (NOT WIN32) AND (NOT CYGWIN) )
     new_ec_test(backslash_not_on_windows path_separator.in "windows\\\\separator2" "^key=value[ \t\n\r]*$")
 endif()
 

--- a/filetree/CMakeLists.txt
+++ b/filetree/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2011-2012 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -29,7 +29,9 @@
 new_ec_test(parent_directory parent_directory.in parent_directory/test.a "^key=value[ \t\n\r]*$")
 
 # Test for EditorConfig file in parent directory and current directory
-new_ec_test(parent_and_current_dir parent_directory.in parent_directory/test.b "^key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*$")
+ec_test_lines(NAME parent_and_current_dir EC_FILE parent_directory.in
+    SRC_FILE parent_directory/test.b
+    EXPECTED "key1=value1[ \t]*" "key2=value2[ \t]*")
 
 # Test for file in parent directory and overloaded by file in current directory
 new_ec_test(parent_dir_overload parent_directory.in parent_directory/test.c "^key=valueB[ \t\n\r]*$")
@@ -50,13 +52,13 @@ new_ec_test(root_file_mixed_case root_file.in root_mixed/test.a "^child=true[ \t
 new_ec_test(root_pattern root_file.in root "^name=root[ \t\n\r]*$")
 
 # Tests path separator match
-new_ec_test(path_separator path_separator.in path/separator "^key=value[ \t\n\r]*$")
+new_ec_test(path_separator path_separator.in path/separator "^key1=value1[ \t\n\r]*$")
 
 # Windows style path separator in the command line should work on Windows, but
 # should not work on other systems
 # TODO figure out how to handle Cygwin
 if(WIN32)
-    set(path_separator_backslash_in_cmd_line_regex "^key=value[ \t\n\r]*$")
+    set(path_separator_backslash_in_cmd_line_regex "^key1=value1[ \t\n\r]*$")
 else(WIN32)
     set(path_separator_backslash_in_cmd_line_regex "^[ \t\n\r]*$")
 endif(WIN32)
@@ -68,7 +70,7 @@ new_ec_test_full_ec_file_path(path_separator_backslash_in_cmd_line
 new_ec_test(nested_path_separator path_separator.in nested/path/separator "^[ \t\n\r]*$")
 
 # Tests path separator match top of path only
-new_ec_test(top_level_path_separator path_separator.in top/of/path "^key=value[ \t\n\r]*$")
+new_ec_test(top_level_path_separator path_separator.in top/of/path "^key2=value2[ \t\n\r]*$")
 
 # Tests path separator match top of path only
 new_ec_test(top_level_path_separator_neg path_separator.in not/top/of/path "^[ \t\n\r]*$")
@@ -81,7 +83,7 @@ new_ec_test(windows_separator2 path_separator.in windows/separator2 "^[ \t\n\r]*
 
 # Globs with backslash in it but should be considered as file name on Non-Windows system
 if( (NOT WIN32) AND (NOT CYGWIN) )
-    new_ec_test(backslash_not_on_windows path_separator.in "windows\\\\separator2" "^key=value[ \t\n\r]*$")
+    new_ec_test(backslash_not_on_windows path_separator.in "windows\\\\separator2" "^key4=value4[ \t\n\r]*$")
 endif()
 
 new_ec_test(path_with_special_chars path_with_special_chars.in "path_with_special_[chars/test.a" "^key=value[ \t\n\r]*$")
@@ -89,7 +91,8 @@ new_ec_test(path_with_special_chars path_with_special_chars.in "path_with_specia
 # Test the unset value with various common properties
 new_ec_test(unset_charset unset.in unset/charset.txt "^charset=unset[ \t\n\r]*$")
 new_ec_test(unset_end_of_line unset.in unset/end_of_line.txt "^end_of_line=unset[ \t\n\r]*$")
-new_ec_test(unset_indent_size unset.in unset/indent_size.txt "^indent_size=unset[ \t\n\r]*tab_width=unset[ \t\n\r]*$")
+ec_test_lines(NAME unset_indent_size EC_FILE unset.in SRC_FILE unset/indent_size.txt
+    EXPECTED "indent_size=unset[ \t]*" "tab_width=unset[ \t]*")
 new_ec_test(unset_indent_style unset.in unset/indent_style.txt "^indent_style=unset[ \t\n\r]*$")
 new_ec_test(unset_insert_final_newline unset.in unset/insert_final_newline.txt "^insert_final_newline=unset[ \t\n\r]*$")
 new_ec_test(unset_tab_width unset.in unset/tab_width.txt "^tab_width=unset[ \t\n\r]*$")

--- a/filetree/path_separator.in
+++ b/filetree/path_separator.in
@@ -3,13 +3,13 @@
 root=true
 
 [path/separator]
-key=value
+key1=value1
 
 [/top/of/path]
-key=value
+key2=value2
 
 [windows\separator]
-key=value
+key3=value3
 
 [windows\\separator2]
-key=value
+key4=value4

--- a/glob/CMakeLists.txt
+++ b/glob/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2011-2014 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,22 +28,28 @@
 # Tests for *
 
 # matches a single characters
-new_ec_test(star_single star.in ace.c "^key=value[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+ec_test_lines(NAME star_single EC_FILE star.in SRC_FILE ace.c
+    EXPECTED "key=value[ \t]*" "keyc=valuec[ \t]*")
 
 # matches zero characters
-new_ec_test(star_zero star.in ae.c "^key=value[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+ec_test_lines(NAME star_zero EC_FILE star.in SRC_FILE ae.c
+    EXPECTED "key=value[ \t]*" "keyc=valuec[ \t]*")
 
 # matches multiple characters
-new_ec_test(star_multiple star.in abcde.c "^key=value[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+ec_test_lines(NAME star_multiple EC_FILE star.in SRC_FILE abcde.c
+    EXPECTED "key=value[ \t]*" "keyc=valuec[ \t]*")
 
 # does not match path separator
 new_ec_test(star_over_slash star.in a/e.c "^[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
 
 # star after a slash
-new_ec_test(star_after_slash star.in Bar/foo.txt "^keyb=valueb[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+ec_test_lines(NAME star_after_slash EC_FILE star.in SRC_FILE Bar/foo.txt
+    EXPECTED "keyb=valueb[ \t]*" "keyc=valuec[ \t]*")
 
 # star matches a dot file after slash
-new_ec_test(star_matches_dot_file_after_slash star.in Bar/.editorconfig "^keyb=valueb[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+ec_test_lines(NAME star_matches_dot_file_after_slash EC_FILE star.in
+    SRC_FILE Bar/.editorconfig
+    EXPECTED "keyb=valueb[ \t]*" "keyc=valuec[ \t]*")
 
 # star matches a dot file
 new_ec_test(star_matches_dot_file star.in .editorconfig "^keyc=valuec[ \t\n\r]*$")

--- a/glob/CMakeLists.txt
+++ b/glob/CMakeLists.txt
@@ -177,7 +177,7 @@ new_ec_test(braces_escaped_brace3 braces.in f.txt "^closing=yes[ \t\n\r]*$")
 
 # escaped backslash
 new_ec_test(braces_escaped_backslash1 braces.in g.txt "^backslash=yes[ \t\n\r]*$")
-if(NOT WIN32) # this case is impossible on Windows.
+if( (NOT WIN32) AND (NOT CYGWIN) )  # this case is impossible on Windows.
     new_ec_test(braces_escaped_backslash2 braces.in \\\\.txt "^backslash=yes[ \t\n\r]*$")
 endif()
 new_ec_test(braces_escaped_backslash3 braces.in i.txt "^backslash=yes[ \t\n\r]*$")

--- a/multi_section.in
+++ b/multi_section.in
@@ -1,0 +1,8 @@
+[*]
+child_wins=no
+
+[test.*]
+from_test_parent=yes
+
+[*.file]
+from_file_parent=yes

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2011-2013 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -27,8 +27,10 @@
 # Basic parser tests
 
 # test repeat sections
-new_ec_test(repeat_sections basic.in a.a "^option1=value1[ \t]*[\n\r]+option2=value2[ \t\n\r]*$")
-new_ec_test(basic_cascade basic.in b.b "^option1=c[ \t]*[\n\r]+option2=b[ \t\n\r]*$")
+ec_test_lines(NAME repeat_sections EC_FILE basic.in SRC_FILE a.a
+    EXPECTED "option1=value1[ \t]*" "option2=value2[ \t]*")
+ec_test_lines(NAME basic_cascade EC_FILE basic.in SRC_FILE b.b
+    EXPECTED "^option1=c[ \t]*" "option2=b[ \t]*")
 
 # Tests for whitespace parsing
 
@@ -52,8 +54,9 @@ new_ec_test(spaces_after_property_value whitespace.in test5.c
     "^key=value[ \t\n\r]*$")
 
 # test blank lines between properties
-new_ec_test(blank_lines_between_properties whitespace.in test6.c 
-    "^key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*$")
+ec_test_lines(NAME blank_lines_between_properties EC_FILE whitespace.in
+    SRC_FILE test6.c
+    EXPECTED "key1=value1[ \t]*" "key2=value2[ \t]*")
 
 # test spaces in section name
 new_ec_test(spaces_in_section_name whitespace.in " test 7 "
@@ -67,7 +70,9 @@ new_ec_test(spaces_before_section_name whitespace.in test8.c
 new_ec_test(spaces_after_section_name whitespace.in test9.c "^key=value[ \t\n\r]*$")
 
 # test spaces at beginning of line between properties
-new_ec_test(spaces_before_middle_property whitespace.in test10.c "^key1=value1[ \t]*[\n\r]+key2=value2[ \t]*[\n\r]+key3=value3[ \t\n\r]*$")
+ec_test_lines(NAME spaces_before_middle_property EC_FILE whitespace.in
+    SRC_FILE test10.c
+    EXPECTED "key1=value1[ \t]*" "key2=value2[ \t]*" "key3=value3[ \t]*")
 
 # test colon seperator with no whitespaces in property assignment
 new_ec_test(colon_sep_no_whitespace whitespace.in test1.d "^key=value[ \t\n\r]*$")
@@ -104,8 +109,8 @@ new_ec_test(comment_before_props comments.in test3.c
     "^key=value[ \t\n\r]*$")
 
 # test comments ignored between properties
-new_ec_test(comment_between_props comments.in test4.c
-    "^key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*$")
+ec_test_lines(NAME comment_between_props EC_FILE comments.in SRC_FILE test4.c
+    EXPECTED "key1=value1[ \t]*" "key2=value2[ \t]*")
 
 # test semicolons at end of property value are included in value
 new_ec_test(semicolon_in_property comments.in test5.c
@@ -132,8 +137,9 @@ new_ec_test(octothorpe_comment_before_props comments.in test9.c
     "^key=value[ \t\n\r]*$")
 
 # test octothorpe comments ignored between properties
-new_ec_test(octothorpe_comment_between_props comments.in test10.c
-    "^key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*$")
+ec_test_lines(NAME octothorpe_comment_between_props EC_FILE comments.in
+    SRC_FILE test10.c
+    EXPECTED "key1=value1[ \t]*" "key2=value2[ \t]*")
 
 # test octothorpe at end of property value are included in value
 new_ec_test(octothorpe_in_property comments.in test11.c

--- a/properties/CMakeLists.txt
+++ b/properties/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2011-2012 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -26,18 +26,21 @@
 
 
 # test tab_width default
-new_ec_test(tab_width_default tab_width_default.in test.c
-    "^indent_style=space[ \t]*[\n\r]+indent_size=4[ \t]*[\n\r]+tab_width=4[\t\n\r]*$")
+ec_test_lines(NAME tab_width_default EC_FILE tab_width_default.in
+    SRC_FILE test.c
+    EXPECTED "indent_style=space[ \t]*" "indent_size=4[ \t]*" "tab_width=4[\t]*")
 
 # Tab_width should not be set to any value if indent_size is "tab" and
 # tab_width is not set
-new_ec_test(tab_width_default_indent_size_tab tab_width_default.in test2.c
-    "^indent_style=tab[ \t]*[\n\r]+indent_size=tab[ \t\n\r]*$")
+ec_test_lines(NAME tab_width_default_indent_size_tab
+    EC_FILE tab_width_default.in SRC_FILE test2.c
+    EXPECTED "indent_style=tab[ \t]*" "indent_size=tab[ \t]*")
 
 # Test indent_size default. When indent_style is "tab", indent_size defaults to
 # "tab".
-new_ec_test(indent_size_default indent_size_default.in test.c
-    "^indent_style=tab[ \t]*[\n\r]+indent_size=tab[ \t\n\r]*$")
+ec_test_lines(NAME indent_size_default EC_FILE indent_size_default.in
+    SRC_FILE test.c
+    EXPECTED "^indent_style=tab[ \t]*" "indent_size=tab[ \t]*")
 
 # Test indent_size default. When indent_style is "tab", indent_size should have
 # no default value for version prior than 0.9.0.
@@ -51,16 +54,28 @@ new_ec_test(indent_size_default_space indent_size_default.in test2.c
 
 # Test indent_size default. When indent_style is "tab" and tab_width is set,
 # indent_size should default to tab_width
-new_ec_test(indent_size_default_with_tab_width indent_size_default.in test3.c
-    "^indent_style=tab[ \t]*[\n\r]+tab_width=2[ \t]*[\n\r]+indent_size=2[ \t\n\r]*$")
+ec_test_lines(
+    NAME indent_size_default_with_tab_width
+    EC_FILE indent_size_default.in
+    SRC_FILE test3.c
+    EXPECTED
+    "indent_style=tab[ \t]*"
+    "tab_width=2[ \t]*"
+    "indent_size=2[ \t]*"
+)
+# test that same property values are lowercased (v0.9.0 properties)
+ec_test_lines(NAME lowercase_values1 EC_FILE lowercase_values.in
+    SRC_FILE test1.c
+    EXPECTED "indent_style=space[ \t]*" "end_of_line=crlf[ \t]*")
 
 # test that same property values are lowercased (v0.9.0 properties)
-new_ec_test(lowercase_values1 lowercase_values.in test1.c
-    "^indent_style=space[ \t]*[\n\r]+end_of_line=crlf[ \t\n\r]*$")
-
-# test that same property values are lowercased (v0.9.0 properties)
-new_ec_test(lowercase_values2 lowercase_values.in test2.c
-    "^insert_final_newline=true[ \t]*[\n\r]+trim_trailing_whitespace=false[ \t]*[\n\r]+charset=utf-8[ \t\n\r]*$")
+ec_test_lines(NAME lowercase_values2 EC_FILE lowercase_values.in
+    SRC_FILE test2.c
+    EXPECTED
+    "insert_final_newline=true[ \t]*"
+    "trim_trailing_whitespace=false[ \t]*"
+    "charset=utf-8[ \t]*"
+)
 
 # test that same property values are not lowercased
 new_ec_test(lowercase_values3 lowercase_values.in test3.c
@@ -69,3 +84,26 @@ new_ec_test(lowercase_values3 lowercase_values.in test3.c
 # test that all property names are lowercased
 new_ec_test(lowercase_names lowercase_names.in test.c
     "^testproperty=testvalue[ \t\n\r]*$")
+
+# Test that values are pulled correctly from multiple sections across
+# multiple editorconfig files
+new_ec_test(multi_section_a multi_section.in "test.file"
+    "(^|[\n\r]+)from_test=yes[ \t\n\r]+")
+
+new_ec_test(multi_section_b multi_section.in "test.file"
+    "(^|[\n\r]+)from_file=yes[ \t\n\r]+")
+
+new_ec_test(multi_section_c multi_section.in "test.file"
+    "(^|[\n\r]+)from_test_parent=yes[ \t\n\r]+")
+
+new_ec_test(multi_section_d multi_section.in "test.file"
+    "(^|[\n\r]+)from_file_parent=yes[ \t\n\r]+")
+
+# ... and that properties in editorconfig files closer to the target file
+# win over properties in editorconfig files closer to the root.
+new_ec_test(multi_section_e multi_section.in "test.file"
+    "(^|[\n\r]+)child_wins=yes[ \t\n\r]+")
+
+new_ec_test_does_not_match(multi_section_f multi_section.in "test.file"
+    "(^|[\n\r]+)child_wins=no[ \t\n\r]+")
+

--- a/properties/multi_section.in
+++ b/properties/multi_section.in
@@ -1,0 +1,8 @@
+[*]
+child_wins=yes
+
+[test.*]
+from_test=yes
+
+[*.file]
+from_file=yes


### PR DESCRIPTION
- Adds new `ec_test_lines` function that adds a test accepting multiple
  output lines in any order.
- Rewrites the pertinent tests to use `ec_test_lines`.
- Bumps the required CMake version up to 3.1.0 (OK per data from @ppalaga [here](https://github.com/editorconfig/editorconfig/issues/375#issuecomment-431036167)).

Fixes editorconfig/editorconfig#375, which has the discussion leading up to this PR.

[editorconfig-core-c](https://github.com/editorconfig/editorconfig-core-c) and my [editorconfig-core-vimscript](https://github.com/cxw42/editorconfig-core-vimscript) both pass 100% of tests with this PR in place.

Note: also includes one commit for the benefit of Cygwin (my development environment) to not run tests that can't possibly succeed on Cygwin.