### PR TITLE
Update tests to permit any order of output lines by sorting the editorconfig output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2011-2012 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -29,11 +29,15 @@
 # testing only.
 project(editorconfig-core-test NONE)
 
+# Where this file lives
+set( tests_cmakelists_dir "${CMAKE_CURRENT_LIST_DIR}" )
+#message( STATUS "Tests are in ${tests_cmakelists_dir}" )
+
 # Only when we are using editorconfig-core-test independently should we check
 # cmake version, set EDITORCONFIG_CMD as cache string, and enable_testing()
 # here.
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-    cmake_minimum_required(VERSION 2.6)
+    cmake_minimum_required(VERSION 3.5)
     set(EDITORCONFIG_CMD "editorconfig" CACHE STRING "editorconfig command.")
     enable_testing()
 endif()
@@ -58,9 +62,30 @@ function(new_ec_test_full_ec_file_path name ec_file src_file regex)
     set_tests_properties(${name} PROPERTIES PASS_REGULAR_EXPRESSION "${regex}")
 endfunction()
 
+# A test that returns multiple lines of output.  CAUTION: filenames used in
+# these tests may not contain semicolons.
+function(new_ec_test_multiline name ec_file src_file regex)
+    #message( STATUS "Building multiline test ${name} with tests_cmakelists_dir ${tests_cmakelists_dir}" )
+    #message( STATUS "List dir ${CMAKE_CURRENT_LIST_DIR}, source dir ${CMAKE_CURRENT_SOURCE_DIR}" )
+    add_test(${name} "cmake"
+                "-D" "EDITORCONFIG_CMD=${EDITORCONFIG_CMD}"
+                    # Since variables aren't autpmatically passed to the inner cmake
+                "-D" "ECARGS:LIST=-f;${ec_file};${CMAKE_CURRENT_SOURCE_DIR}/${src_file}"
+                    # Note: the semicolons separate list elements.
+                "-P" "${tests_cmakelists_dir}/cmake/ec_sort.cmake")
+    set_tests_properties(${name} PROPERTIES PASS_REGULAR_EXPRESSION
+        "^[\n]*${regex}$")
+        # Permit leading \n's because I can't always get rid of them using
+        # only CMake-provided facilities.
+endfunction()
+
+
+# First, make sure the test harness works.
+add_subdirectory(meta)
+
+# Then test the core.
 add_subdirectory(glob)
 add_subdirectory(properties)
 add_subdirectory(parser)
 add_subdirectory(filetree)
 add_subdirectory(cli)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2012 EditorConfig Team
+# Copyright (c) 2011-2018 EditorConfig Team
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -30,8 +30,8 @@
 project(editorconfig-core-test NONE)
 
 # Where this file lives
-set( tests_cmakelists_dir "${CMAKE_CURRENT_LIST_DIR}" )
-#message( STATUS "Tests are in ${tests_cmakelists_dir}" )
+set(tests_cmakelists_dir "${CMAKE_CURRENT_LIST_DIR}")
+#message(STATUS "Tests are in ${tests_cmakelists_dir}")
 
 # Only when we are using editorconfig-core-test independently should we check
 # cmake version, set EDITORCONFIG_CMD as cache string, and enable_testing()
@@ -65,8 +65,8 @@ endfunction()
 # A test that returns multiple lines of output.  CAUTION: filenames used in
 # these tests may not contain semicolons.
 function(new_ec_test_multiline name ec_file src_file regex)
-    #message( STATUS "Building multiline test ${name} with tests_cmakelists_dir ${tests_cmakelists_dir}" )
-    #message( STATUS "List dir ${CMAKE_CURRENT_LIST_DIR}, source dir ${CMAKE_CURRENT_SOURCE_DIR}" )
+    #message(STATUS "Building multiline test ${name} with tests_cmakelists_dir ${tests_cmakelists_dir}")
+    #message(STATUS "List dir ${CMAKE_CURRENT_LIST_DIR}, source dir ${CMAKE_CURRENT_SOURCE_DIR}")
     add_test(${name} "cmake"
                 "-D" "EDITORCONFIG_CMD=${EDITORCONFIG_CMD}"
                     # Since variables aren't autpmatically passed to the inner cmake

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2016 EditorConfig Team
+Copyright (c) 2011-2018 EditorConfig Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2011-2012 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -40,10 +40,13 @@ set_tests_properties(test_short_version_switch PROPERTIES
 
 # Test for multiple input files
 
-# when files are specified on command line
+# when files are specified on command line.  The files can appear in either
+# order in the output, but each file's output line must be grouped with its
+# file header.  Handle this by listing both possibilities manually in the regex.
 add_test(multiple_files_on_command_line ${EDITORCONFIG_CMD} -f cli.in
     "${CMAKE_CURRENT_SOURCE_DIR}/file1.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/file2.cpp")
 set_tests_properties(multiple_files_on_command_line PROPERTIES
     PASS_REGULAR_EXPRESSION
-    "^\\[${CMAKE_CURRENT_SOURCE_DIR}/file1.c\\][ \t]*[\n\r]+key1=value1[ \t]*[\n\r]+\\[${CMAKE_CURRENT_SOURCE_DIR}/file2.cpp\\][ \t]*[\n\r]+key2=value2[ \t\n\r]*$")
+    "^(\\[${CMAKE_CURRENT_SOURCE_DIR}/file1.c\\][ \t]*[\n\r]+key1=value1[ \t]*[\n\r]+\\[${CMAKE_CURRENT_SOURCE_DIR}/file2.cpp\\][ \t]*[\n\r]+key2=value2)|(\\[${CMAKE_CURRENT_SOURCE_DIR}/file2.cpp\\][ \t]*[\n\r]+key2=value2[ \t]*[\n\r]+\\[${CMAKE_CURRENT_SOURCE_DIR}/file1.c\\][ \t]*[\n\r]+key1=value1)[ \t\n\r]*$"
+    )

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2012 EditorConfig Team
+# Copyright (c) 2011-2018 EditorConfig Team
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/almostcat.cmake
+++ b/cmake/almostcat.cmake
@@ -1,0 +1,44 @@
+# almostcat.cmake: print the file named in ${WHICH} to **stderr**.  Puts an
+# extra space at the beginning to suppress CMake's word wrapping.  May add
+# an extra \n at the end because that's what message() does.
+
+# BSD-2-Clause
+# Copyright 2018 Christopher White (cxw42 at GitHub; http://devwrench.com)
+# All rights reserved
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required(VERSION 3.5)
+
+if( "${WHICH}" EQUAL "" )
+    message( FATAL_ERROR "No WHICH parameter specified" )
+    return()
+endif()
+
+#message( FATAL_ERROR " Reading ${WHICH}" )     # Uncomment for debugging
+file( READ "${WHICH}" contents )
+
+# message() will give us an extra \n, so trim one if we can.
+string( REGEX REPLACE "(\r\n|\r|\n)$" "" lines "${lines}" )
+
+# Print, with a leading space as noted above.
+message( " ${contents}" )

--- a/cmake/almostcat.cmake
+++ b/cmake/almostcat.cmake
@@ -29,16 +29,16 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-if( "${WHICH}" EQUAL "" )
-    message( FATAL_ERROR "No WHICH parameter specified" )
+if("${WHICH}" STREQUAL "")
+    message(FATAL_ERROR "No WHICH parameter specified")
     return()
 endif()
 
-#message( FATAL_ERROR " Reading ${WHICH}" )     # Uncomment for debugging
-file( READ "${WHICH}" contents )
+#message(FATAL_ERROR " Reading ${WHICH}")     # Uncomment for debugging
+file(READ "${WHICH}" contents)
 
 # message() will give us an extra \n, so trim one if we can.
-string( REGEX REPLACE "(\r\n|\r|\n)$" "" lines "${lines}" )
+string(REGEX REPLACE "(\r\n|\r|\n)$" "" lines "${lines}")
 
 # Print, with a leading space as noted above.
-message( " ${contents}" )
+message(" ${contents}")

--- a/cmake/ec_sort.cmake
+++ b/cmake/ec_sort.cmake
@@ -30,35 +30,35 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required(VERSION 3.5)
 
 # See documentation links at https://stackoverflow.com/q/12802377/2877364
-set( tests_cmake_ec_sort_dir "${CMAKE_CURRENT_LIST_DIR}" )
-list( APPEND CMAKE_MODULE_PATH "${tests_cmake_ec_sort_dir}/../cmake" )
-include( runandsort )
+set(tests_cmake_ec_sort_dir "${CMAKE_CURRENT_LIST_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${tests_cmake_ec_sort_dir}/../cmake")
+include(runandsort)
 
 # Required parameters are in variables: EDITORCONFIG_CMD and ECARGS
-if( "${ECARGS}" EQUAL "" )
-    message( FATAL_ERROR "No ECARGS parameter specified" )
+if("${ECARGS}" STREQUAL "")
+    message(FATAL_ERROR "No ECARGS parameter specified")
     return()
 endif()
 
 # Uncomment for debugging
-#message( FATAL_ERROR " Running ${EDITORCONFIG_CMD} with ${ECARGS}" )
+#message(FATAL_ERROR " Running ${EDITORCONFIG_CMD} with ${ECARGS}")
 
-run_and_sort( RETVAL lines RETVAL_FAILURE did_fail
+run_and_sort(RETVAL lines RETVAL_FAILURE did_fail
     PGM "${EDITORCONFIG_CMD}"
     ARGS ${ECARGS}
 )
 
-if( ${did_fail} )
-    message( FATAL_ERROR "${EDITORCONFIG_CMD} ${ECARGS} returned a nonzero exit code" )
+if(${did_fail})
+    message(FATAL_ERROR "${EDITORCONFIG_CMD} ${ECARGS} returned a nonzero exit code")
     return()
 endif()
 
 # message() will give us an extra \n, so trim one if we can.
-string( REGEX REPLACE "(\r\n|\r|\n)$" "" lines "${lines}" )
+string(REGEX REPLACE "(\r\n|\r|\n)$" "" lines "${lines}")
 
 # Output **to stderr**.  If we used message(STATUS...), it would print to
 # stdout but also emit a leading "--".
-message( "${lines}" )
+message("${lines}")

--- a/cmake/ec_sort.cmake
+++ b/cmake/ec_sort.cmake
@@ -1,0 +1,64 @@
+# ec_sort.cmake: Run editorconfig and sort its output
+# For use in editorconfig; see
+# https://github.com/editorconfig/editorconfig/issues/375 .
+
+# Call as, e.g.:
+# cmake -D EDITORCONFIG_CMD="../editorconfig" -D ECARGS:LIST="-f;.editorconfig;foo" -P cmake/ec_sort.cmake
+
+# BSD-2-Clause
+# Copyright 2018 Christopher White (cxw42 at GitHub; http://devwrench.com)
+# All rights reserved
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required( VERSION 3.5 )
+
+# See documentation links at https://stackoverflow.com/q/12802377/2877364
+set( tests_cmake_ec_sort_dir "${CMAKE_CURRENT_LIST_DIR}" )
+list( APPEND CMAKE_MODULE_PATH "${tests_cmake_ec_sort_dir}/../cmake" )
+include( runandsort )
+
+# Required parameters are in variables: EDITORCONFIG_CMD and ECARGS
+if( "${ECARGS}" EQUAL "" )
+    message( FATAL_ERROR "No ECARGS parameter specified" )
+    return()
+endif()
+
+# Uncomment for debugging
+#message( FATAL_ERROR " Running ${EDITORCONFIG_CMD} with ${ECARGS}" )
+
+run_and_sort( RETVAL lines RETVAL_FAILURE did_fail
+    PGM "${EDITORCONFIG_CMD}"
+    ARGS ${ECARGS}
+)
+
+if( ${did_fail} )
+    message( FATAL_ERROR "${EDITORCONFIG_CMD} ${ECARGS} returned a nonzero exit code" )
+    return()
+endif()
+
+# message() will give us an extra \n, so trim one if we can.
+string( REGEX REPLACE "(\r\n|\r|\n)$" "" lines "${lines}" )
+
+# Output **to stderr**.  If we used message(STATUS...), it would print to
+# stdout but also emit a leading "--".
+message( "${lines}" )

--- a/cmake/ec_sort.cmake
+++ b/cmake/ec_sort.cmake
@@ -4,6 +4,8 @@
 
 # Call as, e.g.:
 # cmake -D EDITORCONFIG_CMD="../editorconfig" -D ECARGS:LIST="-f;.editorconfig;foo" -P cmake/ec_sort.cmake
+# EDITORCONFIG_CMD may also be list-valued.  EDITORCONFIG_CMD and ECARGS
+# are put together on the command line, in that order, and split by CMake.
 
 # BSD-2-Clause
 # Copyright 2018 Christopher White (cxw42 at GitHub; http://devwrench.com)
@@ -38,6 +40,11 @@ list(APPEND CMAKE_MODULE_PATH "${tests_cmake_ec_sort_dir}/../cmake")
 include(runandsort)
 
 # Required parameters are in variables: EDITORCONFIG_CMD and ECARGS
+if("${EDITORCONFIG_CMD}" STREQUAL "")
+    message(FATAL_ERROR "No EDITORCONFIG_CMD parameter specified")
+    return()
+endif()
+
 if("${ECARGS}" STREQUAL "")
     message(FATAL_ERROR "No ECARGS parameter specified")
     return()
@@ -47,8 +54,7 @@ endif()
 #message(FATAL_ERROR " Running ${EDITORCONFIG_CMD} with ${ECARGS}")
 
 run_and_sort(RETVAL lines RETVAL_FAILURE did_fail
-    PGM "${EDITORCONFIG_CMD}"
-    ARGS ${ECARGS}
+    CMDLINE ${EDITORCONFIG_CMD} ${ECARGS}
 )
 
 if(${did_fail})

--- a/cmake/runandsort.cmake
+++ b/cmake/runandsort.cmake
@@ -1,0 +1,132 @@
+# runandsort.cmake: Run a program and sort its output
+# For use in editorconfig; see
+# https://github.com/editorconfig/editorconfig/issues/375 .
+
+# BSD-2-Clause
+# Copyright 2018 Christopher White (cxw42 at GitHub; http://devwrench.com)
+# All rights reserved
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required( VERSION 3.5 )
+
+# Conventions:
+#   - "P_*" are parameters parsed using cmake_parse_arguments
+#   - Any parameter called "RETVAL", "RETVAL_*", or "*_NAME" should be given
+#       the name of a variable in the caller's scope into which to
+#       store results.
+
+# Run a program with the given arguments, and return its sorted output as
+# a string.
+# CAUTION 1:    May not produce correct output if any output line includes
+#               a semicolon, because that is a list separator in CMake.
+# CAUTION 2:    Depends on sort order of CMake; see discussion at
+#               https://gitlab.kitware.com/cmake/cmake/issues/18551
+#
+# Limitations:
+#   Any \x01 in the string will be corrupted - this routine uses those to work
+#   around CMake limitations.
+
+# Arguments:
+#   RETVAL .  .  .  .  .  .  .  The name of the variable to store the result in
+#   PGM .  .  .  .  .  .  .  .  The program to run
+#   ARGS .  .  .  .  .  .  .  . Any arguments to pass to the program
+#   RETVAL_FAILURE .  .  .  .   If present, a variable that will be set to TRUE
+#                               if PGM returns a non-zero exit code.
+#   CAPTURE_STDERR .  .  .  .   If present, capture stderr instead of stdout
+#   TRIM_INITIAL_LEADING_SPACE  If present, remove initial spaces from the
+#                               first line.  This is to work around a hack
+#                               in almostcat.cmake.
+#
+# Returns:
+#   The sorted stdout of PGM, or the FAILURE string if PGM failed.
+#   PGM's stderr is ignored.
+
+function( run_and_sort )
+    # Argument parsing
+    set( option_keywords CAPTURE_STDERR TRIM_INITIAL_LEADING_SPACE )
+    set( one_value_keywords RETVAL RETVAL_FAILURE PGM )
+    set( multi_value_keywords ARGS )
+    cmake_parse_arguments( P "${option_keywords}" "${one_value_keywords}"
+                            "${multi_value_keywords}" ${ARGN} )
+
+    #message( STATUS "Running ${P_PGM} with ${P_ARGS}" )
+    execute_process( COMMAND "${P_PGM}" ${P_ARGS}
+        RESULT_VARIABLE ep_retval
+        OUTPUT_VARIABLE ep_stdout
+        ERROR_VARIABLE ep_stderr
+    )
+
+    # Which one are we processing?
+    if( ${P_CAPTURE_STDERR} )
+        set( ep_out "${ep_stderr}" )
+    else()
+        set( ep_out "${ep_stdout}" )
+    endif()
+
+    #message( STATUS "Got stdout =${ep_stdout}=" )
+    #message( STATUS "Got stderr =${ep_stderr}=" )
+
+    # Early bail on failure
+    if( NOT( "${ep_retval}" EQUAL "0" ) )
+        set( ${P_RETVAL} "" PARENT_SCOPE )
+        if( "${P_RETVAL_FAILURE}" MATCHES "." )     # if we got a name
+            set( ${P_RETVAL_FAILURE} TRUE PARENT_SCOPE )
+        endif()
+        return()
+    endif()
+
+    # Trim hack
+    if( ${P_TRIM_INITIAL_LEADING_SPACE} )
+        string( REGEX REPLACE "^[ ]+" "" ep_out "${ep_out}" )
+    endif()
+
+    # Change all the semicolons in the output to \x01
+    string( ASCII 1 ONE )
+    string( REPLACE ";" "${ONE}" ep_out "${ep_out}" )
+    #message( STATUS "After escaping =${ep_out}=" )
+
+    # Normalize line endings, just in case
+    string( REGEX REPLACE "\r|\n|\r\n" "\n" ep_out "${ep_out}" )
+    #message( STATUS "After line-endings =${ep_out}=" )
+
+    # Turn the string into a list
+    string( REPLACE "\n" ";" ep_out "${ep_out}" )
+    #message( STATUS "After listifying =${ep_out}=" )
+
+    # Sort the list
+    list( SORT ep_out )
+
+    # Back to individual lines
+    string( REPLACE ";" "\n" ep_out "${ep_out}" )
+    #message( STATUS "After back to lines =${ep_out}=" )
+
+    # And back to semicolons.  Note: I am not trying to reverse line endings.
+    string( REPLACE "${ONE}" ";" ep_out "${ep_out}" )
+    #message( STATUS "After unescaping =${ep_out}=" )
+
+    # Out to the caller
+    set( ${P_RETVAL} "${ep_out}" PARENT_SCOPE )
+    #message( STATUS "Returned =${ep_out}=" )
+
+endfunction( run_and_sort )
+

--- a/cmake/runandsort.cmake
+++ b/cmake/runandsort.cmake
@@ -27,7 +27,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required(VERSION 3.5)
 
 # Conventions:
 #   - "P_*" are parameters parsed using cmake_parse_arguments
@@ -61,72 +61,72 @@ cmake_minimum_required( VERSION 3.5 )
 #   The sorted stdout of PGM, or the FAILURE string if PGM failed.
 #   PGM's stderr is ignored.
 
-function( run_and_sort )
+function(run_and_sort)
     # Argument parsing
-    set( option_keywords CAPTURE_STDERR TRIM_INITIAL_LEADING_SPACE )
-    set( one_value_keywords RETVAL RETVAL_FAILURE PGM )
-    set( multi_value_keywords ARGS )
-    cmake_parse_arguments( P "${option_keywords}" "${one_value_keywords}"
-                            "${multi_value_keywords}" ${ARGN} )
+    set(option_keywords CAPTURE_STDERR TRIM_INITIAL_LEADING_SPACE)
+    set(one_value_keywords RETVAL RETVAL_FAILURE PGM)
+    set(multi_value_keywords ARGS)
+    cmake_parse_arguments(P "${option_keywords}" "${one_value_keywords}"
+                            "${multi_value_keywords}" ${ARGN})
 
-    #message( STATUS "Running ${P_PGM} with ${P_ARGS}" )
-    execute_process( COMMAND "${P_PGM}" ${P_ARGS}
+    #message(STATUS "Running ${P_PGM} with ${P_ARGS}")
+    execute_process(COMMAND "${P_PGM}" ${P_ARGS}
         RESULT_VARIABLE ep_retval
         OUTPUT_VARIABLE ep_stdout
         ERROR_VARIABLE ep_stderr
-    )
+)
 
     # Which one are we processing?
-    if( ${P_CAPTURE_STDERR} )
-        set( ep_out "${ep_stderr}" )
+    if(${P_CAPTURE_STDERR})
+        set(ep_out "${ep_stderr}")
     else()
-        set( ep_out "${ep_stdout}" )
+        set(ep_out "${ep_stdout}")
     endif()
 
-    #message( STATUS "Got stdout =${ep_stdout}=" )
-    #message( STATUS "Got stderr =${ep_stderr}=" )
+    #message(STATUS "Got stdout =${ep_stdout}=")
+    #message(STATUS "Got stderr =${ep_stderr}=")
 
     # Early bail on failure
-    if( NOT( "${ep_retval}" EQUAL "0" ) )
-        set( ${P_RETVAL} "" PARENT_SCOPE )
-        if( "${P_RETVAL_FAILURE}" MATCHES "." )     # if we got a name
-            set( ${P_RETVAL_FAILURE} TRUE PARENT_SCOPE )
+    if(NOT("${ep_retval}" EQUAL "0"))
+        set(${P_RETVAL} "" PARENT_SCOPE)
+        if("${P_RETVAL_FAILURE}" MATCHES ".")     # if we got a name
+            set(${P_RETVAL_FAILURE} TRUE PARENT_SCOPE)
         endif()
         return()
     endif()
 
     # Trim hack
-    if( ${P_TRIM_INITIAL_LEADING_SPACE} )
-        string( REGEX REPLACE "^[ ]+" "" ep_out "${ep_out}" )
+    if(${P_TRIM_INITIAL_LEADING_SPACE})
+        string(REGEX REPLACE "^[ ]+" "" ep_out "${ep_out}")
     endif()
 
     # Change all the semicolons in the output to \x01
-    string( ASCII 1 ONE )
-    string( REPLACE ";" "${ONE}" ep_out "${ep_out}" )
-    #message( STATUS "After escaping =${ep_out}=" )
+    string(ASCII 1 ONE)
+    string(REPLACE ";" "${ONE}" ep_out "${ep_out}")
+    #message(STATUS "After escaping =${ep_out}=")
 
     # Normalize line endings, just in case
-    string( REGEX REPLACE "\r|\n|\r\n" "\n" ep_out "${ep_out}" )
-    #message( STATUS "After line-endings =${ep_out}=" )
+    string(REGEX REPLACE "\r|\n|\r\n" "\n" ep_out "${ep_out}")
+    #message(STATUS "After line-endings =${ep_out}=")
 
     # Turn the string into a list
-    string( REPLACE "\n" ";" ep_out "${ep_out}" )
-    #message( STATUS "After listifying =${ep_out}=" )
+    string(REPLACE "\n" ";" ep_out "${ep_out}")
+    #message(STATUS "After listifying =${ep_out}=")
 
     # Sort the list
-    list( SORT ep_out )
+    list(SORT ep_out)
 
     # Back to individual lines
-    string( REPLACE ";" "\n" ep_out "${ep_out}" )
-    #message( STATUS "After back to lines =${ep_out}=" )
+    string(REPLACE ";" "\n" ep_out "${ep_out}")
+    #message(STATUS "After back to lines =${ep_out}=")
 
     # And back to semicolons.  Note: I am not trying to reverse line endings.
-    string( REPLACE "${ONE}" ";" ep_out "${ep_out}" )
-    #message( STATUS "After unescaping =${ep_out}=" )
+    string(REPLACE "${ONE}" ";" ep_out "${ep_out}")
+    #message(STATUS "After unescaping =${ep_out}=")
 
     # Out to the caller
-    set( ${P_RETVAL} "${ep_out}" PARENT_SCOPE )
-    #message( STATUS "Returned =${ep_out}=" )
+    set(${P_RETVAL} "${ep_out}" PARENT_SCOPE)
+    #message(STATUS "Returned =${ep_out}=")
 
-endfunction( run_and_sort )
+endfunction(run_and_sort)
 

--- a/cmake/runandsort.cmake
+++ b/cmake/runandsort.cmake
@@ -48,8 +48,7 @@ cmake_minimum_required(VERSION 3.5)
 
 # Arguments:
 #   RETVAL .  .  .  .  .  .  .  The name of the variable to store the result in
-#   PGM .  .  .  .  .  .  .  .  The program to run
-#   ARGS .  .  .  .  .  .  .  . Any arguments to pass to the program
+#   CMDLINE .  .  .  .  .  .  . The program to run, and any arguments
 #   RETVAL_FAILURE .  .  .  .   If present, a variable that will be set to TRUE
 #                               if PGM returns a non-zero exit code.
 #   CAPTURE_STDERR .  .  .  .   If present, capture stderr instead of stdout
@@ -64,13 +63,13 @@ cmake_minimum_required(VERSION 3.5)
 function(run_and_sort)
     # Argument parsing
     set(option_keywords CAPTURE_STDERR TRIM_INITIAL_LEADING_SPACE)
-    set(one_value_keywords RETVAL RETVAL_FAILURE PGM)
-    set(multi_value_keywords ARGS)
+    set(one_value_keywords RETVAL RETVAL_FAILURE)
+    set(multi_value_keywords CMDLINE ARGS)
     cmake_parse_arguments(P "${option_keywords}" "${one_value_keywords}"
                             "${multi_value_keywords}" ${ARGN})
 
-    #message(STATUS "Running ${P_PGM} with ${P_ARGS}")
-    execute_process(COMMAND "${P_PGM}" ${P_ARGS}
+    #message(STATUS "Running ${P_CMDLINE}")
+    execute_process(COMMAND ${P_CMDLINE}
         RESULT_VARIABLE ep_retval
         OUTPUT_VARIABLE ep_stdout
         ERROR_VARIABLE ep_stderr

--- a/filetree/CMakeLists.txt
+++ b/filetree/CMakeLists.txt
@@ -54,6 +54,7 @@ new_ec_test(path_separator path_separator.in path/separator "^key=value[ \t\n\r]
 
 # Windows style path separator in the command line should work on Windows, but
 # should not work on other systems
+# TODO figure out how to handle Cygwin
 if(WIN32)
     set(path_separator_backslash_in_cmd_line_regex "^key=value[ \t\n\r]*$")
 else(WIN32)
@@ -79,7 +80,7 @@ new_ec_test(windows_separator path_separator.in windows/separator "^[ \t\n\r]*$"
 new_ec_test(windows_separator2 path_separator.in windows/separator2 "^[ \t\n\r]*$")
 
 # Globs with backslash in it but should be considered as file name on Non-Windows system
-if(NOT WIN32)
+if( (NOT WIN32) AND (NOT CYGWIN) )
     new_ec_test(backslash_not_on_windows path_separator.in "windows\\\\separator2" "^key=value[ \t\n\r]*$")
 endif()
 

--- a/filetree/CMakeLists.txt
+++ b/filetree/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2011-2012 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -24,12 +24,15 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+cmake_minimum_required(VERSION 3.5)
 
 # Test for EditorConfig file in parent directory
 new_ec_test(parent_directory parent_directory.in parent_directory/test.a "^key=value[ \t\n\r]*$")
 
 # Test for EditorConfig file in parent directory and current directory
-new_ec_test(parent_and_current_dir parent_directory.in parent_directory/test.b "^key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*$")
+new_ec_test_multiline(parent_and_current_dir_ML
+    parent_directory.in parent_directory/test.b
+    "key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*")
 
 # Test for file in parent directory and overloaded by file in current directory
 new_ec_test(parent_dir_overload parent_directory.in parent_directory/test.c "^key=valueB[ \t\n\r]*$")
@@ -50,13 +53,12 @@ new_ec_test(root_file_mixed_case root_file.in root_mixed/test.a "^child=true[ \t
 new_ec_test(root_pattern root_file.in root "^name=root[ \t\n\r]*$")
 
 # Tests path separator match
-new_ec_test(path_separator path_separator.in path/separator "^key=value[ \t\n\r]*$")
+new_ec_test(path_separator path_separator.in path/separator "^key1=value1[ \t\n\r]*$")
 
 # Windows style path separator in the command line should work on Windows, but
-# should not work on other systems
-# TODO figure out how to handle Cygwin
+# should not work on other systems (including Cygwin)
 if(WIN32)
-    set(path_separator_backslash_in_cmd_line_regex "^key=value[ \t\n\r]*$")
+    set(path_separator_backslash_in_cmd_line_regex "^key1=value1[ \t\n\r]*$")
 else(WIN32)
     set(path_separator_backslash_in_cmd_line_regex "^[ \t\n\r]*$")
 endif(WIN32)
@@ -68,7 +70,7 @@ new_ec_test_full_ec_file_path(path_separator_backslash_in_cmd_line
 new_ec_test(nested_path_separator path_separator.in nested/path/separator "^[ \t\n\r]*$")
 
 # Tests path separator match top of path only
-new_ec_test(top_level_path_separator path_separator.in top/of/path "^key=value[ \t\n\r]*$")
+new_ec_test(top_level_path_separator path_separator.in top/of/path "^key2=value2[ \t\n\r]*$")
 
 # Tests path separator match top of path only
 new_ec_test(top_level_path_separator_neg path_separator.in not/top/of/path "^[ \t\n\r]*$")
@@ -81,15 +83,17 @@ new_ec_test(windows_separator2 path_separator.in windows/separator2 "^[ \t\n\r]*
 
 # Globs with backslash in it but should be considered as file name on Non-Windows system
 if( (NOT WIN32) AND (NOT CYGWIN) )
-    new_ec_test(backslash_not_on_windows path_separator.in "windows\\\\separator2" "^key=value[ \t\n\r]*$")
+    new_ec_test(backslash_not_on_windows path_separator.in "windows\\\\separator2" "^key4=value4[ \t\n\r]*$")
 endif()
 
 new_ec_test(path_with_special_chars path_with_special_chars.in "path_with_special_[chars/test.a" "^key=value[ \t\n\r]*$")
+## " <-- resync the syntax highlighter
 
 # Test the unset value with various common properties
 new_ec_test(unset_charset unset.in unset/charset.txt "^charset=unset[ \t\n\r]*$")
 new_ec_test(unset_end_of_line unset.in unset/end_of_line.txt "^end_of_line=unset[ \t\n\r]*$")
-new_ec_test(unset_indent_size unset.in unset/indent_size.txt "^indent_size=unset[ \t\n\r]*tab_width=unset[ \t\n\r]*$")
+new_ec_test_multiline(unset_indent_size_ML unset.in unset/indent_size.txt
+    "indent_size=unset[ \t\n\r]*tab_width=unset[ \t\n\r]*")
 new_ec_test(unset_indent_style unset.in unset/indent_style.txt "^indent_style=unset[ \t\n\r]*$")
 new_ec_test(unset_insert_final_newline unset.in unset/insert_final_newline.txt "^insert_final_newline=unset[ \t\n\r]*$")
 new_ec_test(unset_tab_width unset.in unset/tab_width.txt "^tab_width=unset[ \t\n\r]*$")

--- a/filetree/CMakeLists.txt
+++ b/filetree/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2012 EditorConfig Team
+# Copyright (c) 2011-2018 EditorConfig Team
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -82,7 +82,7 @@ new_ec_test(windows_separator path_separator.in windows/separator "^[ \t\n\r]*$"
 new_ec_test(windows_separator2 path_separator.in windows/separator2 "^[ \t\n\r]*$")
 
 # Globs with backslash in it but should be considered as file name on Non-Windows system
-if( (NOT WIN32) AND (NOT CYGWIN) )
+if((NOT WIN32) AND (NOT CYGWIN))
     new_ec_test(backslash_not_on_windows path_separator.in "windows\\\\separator2" "^key4=value4[ \t\n\r]*$")
 endif()
 

--- a/filetree/path_separator.in
+++ b/filetree/path_separator.in
@@ -3,13 +3,13 @@
 root=true
 
 [path/separator]
-key=value
+key1=value1
 
 [/top/of/path]
-key=value
+key2=value2
 
 [windows\separator]
-key=value
+key3=value3
 
 [windows\\separator2]
-key=value
+key4=value4

--- a/glob/CMakeLists.txt
+++ b/glob/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2014 EditorConfig Team
+# Copyright (c) 2011-2018 EditorConfig Team
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -23,7 +23,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-
 
 # Tests for *
 
@@ -177,7 +176,7 @@ new_ec_test(braces_escaped_brace3 braces.in f.txt "^closing=yes[ \t\n\r]*$")
 
 # escaped backslash
 new_ec_test(braces_escaped_backslash1 braces.in g.txt "^backslash=yes[ \t\n\r]*$")
-if( (NOT WIN32) AND (NOT CYGWIN) )  # this case is impossible on Windows.
+if((NOT WIN32) AND (NOT CYGWIN))    # this case is impossible on Windows.
     new_ec_test(braces_escaped_backslash2 braces.in \\\\.txt "^backslash=yes[ \t\n\r]*$")
 endif()
 new_ec_test(braces_escaped_backslash3 braces.in i.txt "^backslash=yes[ \t\n\r]*$")

--- a/glob/CMakeLists.txt
+++ b/glob/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2011-2014 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,22 +28,22 @@
 # Tests for *
 
 # matches a single characters
-new_ec_test(star_single star.in ace.c "^key=value[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+new_ec_test_multiline(star_single_ML star.in ace.c "key=value[ \t\n\r]+keyc=valuec[ \t\n\r]*")
 
 # matches zero characters
-new_ec_test(star_zero star.in ae.c "^key=value[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+new_ec_test_multiline(star_zero_ML star.in ae.c "key=value[ \t\n\r]+keyc=valuec[ \t\n\r]*")
 
 # matches multiple characters
-new_ec_test(star_multiple star.in abcde.c "^key=value[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+new_ec_test_multiline(star_multiple_ML star.in abcde.c "key=value[ \t\n\r]+keyc=valuec[ \t\n\r]*")
 
 # does not match path separator
 new_ec_test(star_over_slash star.in a/e.c "^[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
 
 # star after a slash
-new_ec_test(star_after_slash star.in Bar/foo.txt "^keyb=valueb[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+new_ec_test_multiline(star_after_slash_ML star.in Bar/foo.txt "keyb=valueb[ \t\n\r]+keyc=valuec[ \t\n\r]*")
 
 # star matches a dot file after slash
-new_ec_test(star_matches_dot_file_after_slash star.in Bar/.editorconfig "^keyb=valueb[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+new_ec_test_multiline(star_matches_dot_file_after_slash_ML star.in Bar/.editorconfig "keyb=valueb[ \t\n\r]+keyc=valuec[ \t\n\r]*")
 
 # star matches a dot file
 new_ec_test(star_matches_dot_file star.in .editorconfig "^keyc=valuec[ \t\n\r]*$")

--- a/glob/CMakeLists.txt
+++ b/glob/CMakeLists.txt
@@ -177,7 +177,7 @@ new_ec_test(braces_escaped_brace3 braces.in f.txt "^closing=yes[ \t\n\r]*$")
 
 # escaped backslash
 new_ec_test(braces_escaped_backslash1 braces.in g.txt "^backslash=yes[ \t\n\r]*$")
-if(NOT WIN32) # this case is impossible on Windows.
+if( (NOT WIN32) AND (NOT CYGWIN) )  # this case is impossible on Windows.
     new_ec_test(braces_escaped_backslash2 braces.in \\\\.txt "^backslash=yes[ \t\n\r]*$")
 endif()
 new_ec_test(braces_escaped_backslash3 braces.in i.txt "^backslash=yes[ \t\n\r]*$")

--- a/meta/CMakeLists.txt
+++ b/meta/CMakeLists.txt
@@ -25,21 +25,21 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required(VERSION 3.5)
 
-set( tests_meta_cmakelists_dir "${CMAKE_CURRENT_LIST_DIR}" )
+set(tests_meta_cmakelists_dir "${CMAKE_CURRENT_LIST_DIR}")
 
 # Line separator regex, for convenience
-set( L "[ \t\n\r]+" )
+set(L "[ \t\n\r]+")
 
-message( STATUS "meta: Using editorconfig ${EDITORCONFIG_CMD}" )
+message(STATUS "meta: Using editorconfig ${EDITORCONFIG_CMD}")
 
 # Test run_and_sort()
-add_test( meta_runandsort cmake -P "${tests_meta_cmakelists_dir}/sample.cmake" )
-set_tests_properties( meta_runandsort PROPERTIES PASS_REGULAR_EXPRESSION
-    "^[\n]*0${L}a;b${L}b;c${L}b;e${L}b;f${L}c;b;a${L}d${L}$" )
+add_test(meta_runandsort cmake -P "${tests_meta_cmakelists_dir}/sample.cmake")
+set_tests_properties(meta_runandsort PROPERTIES PASS_REGULAR_EXPRESSION
+    "^[\n]*0${L}a;b${L}b;c${L}b;e${L}b;f${L}c;b;a${L}d${L}$")
     # Have to permit leading \n's - I don't know how to get rid of them
 
 # Test the new multiline macro on a simple case
-new_ec_test_multiline( meta_multiline meta.in meta.c
-    "^[\n]*answer=42${L}$" )
+new_ec_test_multiline(meta_multiline meta.in meta.c
+    "^[\n]*answer=42${L}$")

--- a/meta/CMakeLists.txt
+++ b/meta/CMakeLists.txt
@@ -1,0 +1,45 @@
+# tests/meta/CMakeLists.txt: Test of the test harness for editorconfig.
+
+# BSD-2-Clause
+# Copyright 2018 Christopher White (cxw42 at GitHub; http://devwrench.com)
+# All rights reserved
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required( VERSION 3.5 )
+
+set( tests_meta_cmakelists_dir "${CMAKE_CURRENT_LIST_DIR}" )
+
+# Line separator regex, for convenience
+set( L "[ \t\n\r]+" )
+
+message( STATUS "meta: Using editorconfig ${EDITORCONFIG_CMD}" )
+
+# Test run_and_sort()
+add_test( meta_runandsort cmake -P "${tests_meta_cmakelists_dir}/sample.cmake" )
+set_tests_properties( meta_runandsort PROPERTIES PASS_REGULAR_EXPRESSION
+    "^[\n]*0${L}a;b${L}b;c${L}b;e${L}b;f${L}c;b;a${L}d${L}$" )
+    # Have to permit leading \n's - I don't know how to get rid of them
+
+# Test the new multiline macro on a simple case
+new_ec_test_multiline( meta_multiline meta.in meta.c
+    "^[\n]*answer=42${L}$" )

--- a/meta/meta.in
+++ b/meta/meta.in
@@ -1,0 +1,2 @@
+[meta.c]
+answer=42

--- a/meta/sample.cmake
+++ b/meta/sample.cmake
@@ -9,8 +9,8 @@ include( runandsort )
 
 run_and_sort( RETVAL lines RETVAL_FAILURE did_fail
     CAPTURE_STDERR TRIM_INITIAL_LEADING_SPACE   # since we're using almostcat
-    PGM "cmake"
-    ARGS "-DWHICH:STRING=${tests_meta_sample_dir}/sample.txt" "-P" "${tests_meta_sample_dir}/../cmake/almostcat.cmake"
+    CMDLINE "cmake" "-DWHICH:STRING=${tests_meta_sample_dir}/sample.txt"
+            "-P" "${tests_meta_sample_dir}/../cmake/almostcat.cmake"
 )       # Don't use cat(1) since we might be running on Windows
 
 if( ${did_fail} )

--- a/meta/sample.cmake
+++ b/meta/sample.cmake
@@ -1,0 +1,31 @@
+# sample.cmake: Tests run_and_sort to make sure it's working.
+
+cmake_minimum_required(VERSION 3.5)
+
+# See documentation links at https://stackoverflow.com/q/12802377/2877364
+set( tests_meta_sample_dir "${CMAKE_CURRENT_LIST_DIR}" )
+list( APPEND CMAKE_MODULE_PATH "${tests_meta_sample_dir}/../cmake" )
+include( runandsort )
+
+run_and_sort( RETVAL lines RETVAL_FAILURE did_fail
+    CAPTURE_STDERR TRIM_INITIAL_LEADING_SPACE   # since we're using almostcat
+    PGM "cmake"
+    ARGS "-DWHICH:STRING=${tests_meta_sample_dir}/sample.txt" "-P" "${tests_meta_sample_dir}/../cmake/almostcat.cmake"
+)       # Don't use cat(1) since we might be running on Windows
+
+if( ${did_fail} )
+    message( FATAL_ERROR "Program returned a nonzero exit code" )
+    return()
+endif()
+
+# message() will give us an extra \n, so trim one if we can.
+string( REGEX REPLACE "(\r\n|\r|\n)$" "" lines "${lines}" )
+
+message( "${lines}" )
+# This outputs to stderr, and prints nothing extra except for a \n at the end
+
+# Note that message( STATUS "${lines}" ) doesn't work because it outputs a "--"
+# before the actual content.
+
+# You could also use execute_process( COMMAND "echo" "${lines}" )
+# or cmake -E echo, but I think the message() call is good enough.

--- a/meta/sample.txt
+++ b/meta/sample.txt
@@ -1,0 +1,7 @@
+b;f
+b;c
+b;e
+a;b
+c;b;a
+d
+0

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2013 EditorConfig Team
+# Copyright (c) 2011-2018 EditorConfig Team
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2011-2013 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -27,8 +27,8 @@
 # Basic parser tests
 
 # test repeat sections
-new_ec_test(repeat_sections basic.in a.a "^option1=value1[ \t]*[\n\r]+option2=value2[ \t\n\r]*$")
-new_ec_test(basic_cascade basic.in b.b "^option1=c[ \t]*[\n\r]+option2=b[ \t\n\r]*$")
+new_ec_test_multiline(repeat_sections_ML basic.in a.a "option1=value1[ \t]*[\n\r]+option2=value2[ \t\n\r]*")
+new_ec_test_multiline(basic_cascade_ML basic.in b.b "option1=c[ \t]*[\n\r]+option2=b[ \t\n\r]*")
 
 # Tests for whitespace parsing
 
@@ -52,8 +52,8 @@ new_ec_test(spaces_after_property_value whitespace.in test5.c
     "^key=value[ \t\n\r]*$")
 
 # test blank lines between properties
-new_ec_test(blank_lines_between_properties whitespace.in test6.c 
-    "^key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*$")
+new_ec_test_multiline(blank_lines_between_properties_ML whitespace.in test6.c
+    "key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*")
 
 # test spaces in section name
 new_ec_test(spaces_in_section_name whitespace.in " test 7 "
@@ -67,7 +67,8 @@ new_ec_test(spaces_before_section_name whitespace.in test8.c
 new_ec_test(spaces_after_section_name whitespace.in test9.c "^key=value[ \t\n\r]*$")
 
 # test spaces at beginning of line between properties
-new_ec_test(spaces_before_middle_property whitespace.in test10.c "^key1=value1[ \t]*[\n\r]+key2=value2[ \t]*[\n\r]+key3=value3[ \t\n\r]*$")
+new_ec_test_multiline(spaces_before_middle_property_ML whitespace.in test10.c
+    "key1=value1[ \t]*[\n\r]+key2=value2[ \t]*[\n\r]+key3=value3[ \t\n\r]*")
 
 # test colon seperator with no whitespaces in property assignment
 new_ec_test(colon_sep_no_whitespace whitespace.in test1.d "^key=value[ \t\n\r]*$")
@@ -104,8 +105,8 @@ new_ec_test(comment_before_props comments.in test3.c
     "^key=value[ \t\n\r]*$")
 
 # test comments ignored between properties
-new_ec_test(comment_between_props comments.in test4.c
-    "^key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*$")
+new_ec_test_multiline(comment_between_props_ML comments.in test4.c
+    "key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*")
 
 # test semicolons at end of property value are included in value
 new_ec_test(semicolon_in_property comments.in test5.c
@@ -132,8 +133,8 @@ new_ec_test(octothorpe_comment_before_props comments.in test9.c
     "^key=value[ \t\n\r]*$")
 
 # test octothorpe comments ignored between properties
-new_ec_test(octothorpe_comment_between_props comments.in test10.c
-    "^key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*$")
+new_ec_test_multiline(octothorpe_comment_between_props_ML comments.in test10.c
+    "key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*")
 
 # test octothorpe at end of property value are included in value
 new_ec_test(octothorpe_in_property comments.in test11.c

--- a/properties/CMakeLists.txt
+++ b/properties/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2012 EditorConfig Team
+# Copyright (c) 2011-2018 EditorConfig Team
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -23,7 +23,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-
 
 # test tab_width default
 new_ec_test_multiline(tab_width_default_ML tab_width_default.in test.c
@@ -57,7 +56,7 @@ new_ec_test_multiline(indent_size_default_with_tab_width_ML
 
 # test that same property values are lowercased (v0.9.0 properties)
 new_ec_test_multiline(lowercase_values1_ML lowercase_values.in test1.c
-    "end_of_line=crlf[ \t]*[\n\r]+indent_style=space[ \t\n\r]*" )
+    "end_of_line=crlf[ \t]*[\n\r]+indent_style=space[ \t\n\r]*")
 
 # test that same property values are lowercased (v0.9.0 properties)
 new_ec_test_multiline(lowercase_values2_ML lowercase_values.in test2.c

--- a/properties/CMakeLists.txt
+++ b/properties/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2011-2012 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -26,18 +26,18 @@
 
 
 # test tab_width default
-new_ec_test(tab_width_default tab_width_default.in test.c
-    "^indent_style=space[ \t]*[\n\r]+indent_size=4[ \t]*[\n\r]+tab_width=4[\t\n\r]*$")
+new_ec_test_multiline(tab_width_default_ML tab_width_default.in test.c
+    "indent_size=4[ \t]*[\n\r]+indent_style=space[ \t]*[\n\r]+tab_width=4[\t\n\r]*")
 
 # Tab_width should not be set to any value if indent_size is "tab" and
 # tab_width is not set
-new_ec_test(tab_width_default_indent_size_tab tab_width_default.in test2.c
-    "^indent_style=tab[ \t]*[\n\r]+indent_size=tab[ \t\n\r]*$")
+new_ec_test_multiline(tab_width_default_indent_size_tab_ML tab_width_default.in test2.c
+    "indent_size=tab[ \t]*[\n\r]+indent_style=tab[ \t\n\r]*")
 
 # Test indent_size default. When indent_style is "tab", indent_size defaults to
 # "tab".
-new_ec_test(indent_size_default indent_size_default.in test.c
-    "^indent_style=tab[ \t]*[\n\r]+indent_size=tab[ \t\n\r]*$")
+new_ec_test_multiline(indent_size_default_ML indent_size_default.in test.c
+    "indent_size=tab[ \t]*[\n\r]+indent_style=tab[ \t\n\r]*")
 
 # Test indent_size default. When indent_style is "tab", indent_size should have
 # no default value for version prior than 0.9.0.
@@ -51,16 +51,17 @@ new_ec_test(indent_size_default_space indent_size_default.in test2.c
 
 # Test indent_size default. When indent_style is "tab" and tab_width is set,
 # indent_size should default to tab_width
-new_ec_test(indent_size_default_with_tab_width indent_size_default.in test3.c
-    "^indent_style=tab[ \t]*[\n\r]+tab_width=2[ \t]*[\n\r]+indent_size=2[ \t\n\r]*$")
+new_ec_test_multiline(indent_size_default_with_tab_width_ML
+    indent_size_default.in test3.c
+    "indent_size=2[ \t]*[\n\r]+indent_style=tab[ \t]*[\n\r]+tab_width=2[ \t\n\r]*")
 
 # test that same property values are lowercased (v0.9.0 properties)
-new_ec_test(lowercase_values1 lowercase_values.in test1.c
-    "^indent_style=space[ \t]*[\n\r]+end_of_line=crlf[ \t\n\r]*$")
+new_ec_test_multiline(lowercase_values1_ML lowercase_values.in test1.c
+    "end_of_line=crlf[ \t]*[\n\r]+indent_style=space[ \t\n\r]*" )
 
 # test that same property values are lowercased (v0.9.0 properties)
-new_ec_test(lowercase_values2 lowercase_values.in test2.c
-    "^insert_final_newline=true[ \t]*[\n\r]+trim_trailing_whitespace=false[ \t]*[\n\r]+charset=utf-8[ \t\n\r]*$")
+new_ec_test_multiline(lowercase_values2_ML lowercase_values.in test2.c
+    "charset=utf-8[ \t]*[\n\r]+insert_final_newline=true[ \t]*[\n\r]+trim_trailing_whitespace=false[ \t\n\r]*$")
 
 # test that same property values are not lowercased
 new_ec_test(lowercase_values3 lowercase_values.in test3.c


### PR DESCRIPTION
@xuhdev @ppalaga Here we go again! :D

- Fixes editorconfig/editorconfig#375, which has the discussion leading up to this PR.
- Replaces #22 per https://github.com/editorconfig/editorconfig-core-test/pull/22#issuecomment-435235532

- Adds new `new_ec_test_multiline` function that adds a test accepting multiple
  output lines in any order.  The matching regex for this function must be specified in CMake's sort order - see discussion at https://gitlab.kitware.com/cmake/cmake/issues/18551
- Rewrites the pertinent tests to use `new_ec_test_multiline`.
- Bumps the required CMake version up to 3.5.0 per @xuhdev at https://github.com/editorconfig/editorconfig-core-test/pull/22#discussion_r228741464

[editorconfig-core-c](https://github.com/editorconfig/editorconfig-core-c) and my [editorconfig-core-vimscript](https://github.com/cxw42/editorconfig-core-vimscript) both pass 100% of tests on Cygwin **(edit) and Windows** with this PR in place (except for utf-8 filenames).

Note: also includes one commit for the benefit of Cygwin (my development environment) to not run tests that can't possibly succeed on Cygwin.

**ppalaga**: Would you please test your Java CI?

**Edit** I have now run these tests on mingw-w64 x86 with Windows CMake 3.6.1 in cmd.  All pass except for utf_8_char, which I didn't touch :) .  I see per [this](https://ci.appveyor.com/project/ppalaga/editorconfig-core-c/build/1.0.92?fullLog=true#L1049) (linked from https://github.com/editorconfig/editorconfig-core-c/pull/31#issue-154810185) that this is a known issue on Windows.