### PR TITLE
Test adjacent nested braces

### DIFF
--- a/glob/CMakeLists.txt
+++ b/glob/CMakeLists.txt
@@ -156,6 +156,20 @@ new_ec_test(braces_nested3 braces.in word.g "^nested=true[ \t\n\r]*$")
 new_ec_test(braces_nested4 braces.in {also}.g "^nested=true[ \t\n\r]*$")
 new_ec_test(braces_nested5 braces.in this.g "^nested=true[ \t\n\r]*$")
 
+# nested braces, adjacent at start
+new_ec_test(braces_nested_start1 braces.in {{a,b},c}.k "^[ \t\n\r]*$")
+new_ec_test(braces_nested_start2 braces.in {a,b}.k "^[ \t\n\r]*$")
+new_ec_test(braces_nested_start3 braces.in a.k "^nested_start=true[ \t\n\r]*$")
+new_ec_test(braces_nested_start4 braces.in b.k "^nested_start=true[ \t\n\r]*$")
+new_ec_test(braces_nested_start5 braces.in c.k "^nested_start=true[ \t\n\r]*$")
+
+# nested braces, adjacent at end
+new_ec_test(braces_nested_end1 braces.in {a,{b,c}}.l "^[ \t\n\r]*$")
+new_ec_test(braces_nested_end2 braces.in {b,c}.l "^[ \t\n\r]*$")
+new_ec_test(braces_nested_end3 braces.in a.l "^nested_end=true[ \t\n\r]*$")
+new_ec_test(braces_nested_end4 braces.in b.l "^nested_end=true[ \t\n\r]*$")
+new_ec_test(braces_nested_end5 braces.in c.l "^nested_end=true[ \t\n\r]*$")
+
 # closing inside beginning
 new_ec_test(braces_closing_in_beginning braces.in {},b}.h "^closing=inside[ \t\n\r]*$")
 

--- a/glob/braces.in
+++ b/glob/braces.in
@@ -30,6 +30,14 @@ closing=false
 [{word,{also},this}.g]
 nested=true
 
+; nested braces, adjacent at start
+[{{a,b},c}.k]
+nested_start=true
+
+; nested braces, adjacent at end
+[{a,{b,c}}.l]
+nested_end=true
+
 ; closing inside beginning
 [{},b}.h]
 closing=inside


### PR DESCRIPTION
Nested braces should work correctly when they are adjacent at the start, end, or both.  However, this was not handled correctly in editorconfig-core-py.  This PR adds tests to cover this case.

I have confirmed that these tests all pass for editorconfig-core-c while 1, 3, 4, and 5 fail for editorconfig-core-py without editorconfig/editorconfig-core-py#33 and pass once applied.

Thanks for considering,
Kevin