### PR TITLE
Add/update tests of `#`, `;`, `\#`, `\;` in values

### DIFF
--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -80,9 +80,15 @@ new_ec_test(comment_before_props comments.in test3.c
 new_ec_test_multiline(comment_between_props_ML comments.in test4.c
     "key1=value1[ \t]*[\n\r]+key2=value2[ \t\n\r]*")
 
-# test semicolons at end of property value are included in value
-new_ec_test(semicolon_in_property comments.in test5.c
-    "^key=value; not comment[ \t\n\r]*$")
+# test semicolons and hashes at end of property value are included in value
+new_ec_test(semicolon_or_hash_in_property comments.in test5.c
+    "^key1=value; not comment[\n\r]+key2=value # not comment[ \t\n\r]*$")
+
+# test that backslashes before semicolons and hashes in property values
+# are included in value.
+# NOTE: [\\] matches a single literal backslash.
+new_ec_test(backslashed_semicolon_or_hash_in_property comments.in test6.c
+    "^key1=value [\\]; not comment[\n\r]+key2=value [\\]# not comment[ \t\n\r]*$")
 
 # test escaped semicolons are included in section names
 new_ec_test(escaped_semicolon_in_section comments.in "test;.c"

--- a/parser/comments.in
+++ b/parser/comments.in
@@ -11,13 +11,15 @@ key1=value1
 ; Comment between properties ignored
 key2=value2
 
-; Semicolon at end of value read as part of value
+; Semicolon or hash at end of value read as part of value
 [test5.c]
-key=value; not comment
+key1=value; not comment
+key2=value # not comment
 
-; Escaped semicolon in value
+; Backslash before a semicolon or hash is part of the value
 [test6.c]
-key=value \; not comment
+key1=value \; not comment
+key2=value \# not comment
 
 ; Escaped semicolon in section name
 [test\;.c]


### PR DESCRIPTION
This implements the specification changes made by https://github.com/editorconfig/specification/pull/31 .

- A hash or semicolon in a value is part of the value, not the beginning of a comment.
- Backslashes before hashes or semicolons are part of the value as well, not an escaping mechanism.
- This supersedes the change made in #33.