### PR TITLE
Add tests that `/` makes a glob not match in subdirs

### DIFF
--- a/glob/CMakeLists.txt
+++ b/glob/CMakeLists.txt
@@ -47,6 +47,14 @@ new_ec_test_multiline(star_matches_dot_file_after_slash_ML star.in Bar/.editorco
 # star matches a dot file
 new_ec_test(star_matches_dot_file star.in .editorconfig "^keyc=valuec[ \t\n\r]*$")
 
+# Slash makes the pattern not match in subdirectories
+new_ec_test_multiline(star_after_slash_ML_in_subdir star.in
+    bat/Bar/foo.txt "^[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+
+# Slash makes the pattern not match dotfiles in subdirectories
+new_ec_test_multiline(star_matches_dot_file_after_slash_ML_in_subdir star.in
+    bat/Bar/.editorconfig "^[ \t\n\r]*keyc=valuec[ \t\n\r]*$")
+
 # Tests for ?
 
 # matches a single character


### PR DESCRIPTION
Closes https://github.com/editorconfig/editorconfig/issues/509, which says:

> What about a/*.c? Will it match files of the form /foo/**/a/*.c or only /foo/a/*.c?

Per https://github.com/editorconfig/specification/pull/49, the answer is that it only matches `/foo/a/*.c`.

This PR adds core tests of that behaviour.