### PR TITLE
Bump CMake min requirement to 3.16.3 everywhere

### DIFF
--- a/cmake/almostcat.cmake
+++ b/cmake/almostcat.cmake
@@ -27,7 +27,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16.3)
 
 if("${WHICH}" STREQUAL "")
     message(FATAL_ERROR "No WHICH parameter specified")

--- a/cmake/ec_sort.cmake
+++ b/cmake/ec_sort.cmake
@@ -32,7 +32,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16.3)
 
 # See documentation links at https://stackoverflow.com/q/12802377/2877364
 set(tests_cmake_ec_sort_dir "${CMAKE_CURRENT_LIST_DIR}")

--- a/cmake/runandsort.cmake
+++ b/cmake/runandsort.cmake
@@ -27,7 +27,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16.3)
 
 # Conventions:
 #   - "P_*" are parameters parsed using cmake_parse_arguments

--- a/filetree/CMakeLists.txt
+++ b/filetree/CMakeLists.txt
@@ -24,8 +24,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-cmake_minimum_required(VERSION 3.5)
-
 # Test for EditorConfig file in parent directory
 new_ec_test(parent_directory parent_directory.in parent_directory/test.a "^key=value[ \t\n\r]*$")
 

--- a/meta/CMakeLists.txt
+++ b/meta/CMakeLists.txt
@@ -25,8 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.5)
-
 set(tests_meta_cmakelists_dir "${CMAKE_CURRENT_LIST_DIR}")
 
 # Line separator regex, for convenience


### PR DESCRIPTION
To keep them aligned with the main CMakeLists.txt file.

Seems to be the cause of https://github.com/editorconfig/editorconfig-core-py/issues/51, since CMake warned about dropping compatibility below 3.10 a few versions ago.